### PR TITLE
Clean up and document lazyvim config

### DIFF
--- a/nvim/.lazy.lua
+++ b/nvim/.lazy.lua
@@ -1,0 +1,5 @@
+-- Project-local overrides can go here if you choose to trust the file.
+-- This is empty intentionally; see README for details.
+
+return {}
+

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -1,0 +1,84 @@
+### LazyVim Starter (Lean)
+
+This is a clean, documented LazyVim setup you can use as a solid base. It trims unused plugins and avoids common pitfalls (like colorscheme + bufferline highlight issues).
+
+#### Install
+
+1) Backup your current config and link/copy this folder to `~/.config/nvim`.
+
+```bash
+mv ~/.config/nvim ~/.config/nvim.bak 2>/dev/null || true
+cp -r /workspace/nvim ~/.config/nvim
+```
+
+2) Start Neovim. Lazy will bootstrap itself automatically.
+
+#### Structure
+
+```
+~/.config/nvim
+├── init.lua                  # sets leaders and loads lazy
+├── lua
+│   ├── config
+│   │   ├── lazy.lua          # bootstrap lazy.nvim + plugin spec imports
+│   │   ├── options.lua       # core editor options
+│   │   ├── keymaps.lua       # minimal base keymaps
+│   │   └── autocmds.lua      # small generic autocmds
+│   └── plugins               # your plugin specs (one concern per file)
+│       ├── core.lua          # colorscheme and LazyVim opts
+│       ├── ui.lua            # bufferline, lualine, theme plugin
+│       └── disabled.lua      # plugins disabled explicitly
+└── README.md
+```
+
+#### Why this fixes your startup error
+
+LazyVim’s built‑in `colorscheme.lua` sometimes overrides bufferline highlights in ways that break when themes/plugins change. This starter provides a minimal `bufferline` config and loads a theme plugin explicitly, avoiding the problematic highlight mutation path.
+
+#### Best practices
+
+- **One concern per file**: put each feature or plugin family in its own spec file in `lua/plugins/`.
+- **Prefer `opts` over imperative config**: supply options tables; avoid calling setup twice.
+- **Disable unused plugins**: use `lua/plugins/disabled.lua` with `{ name, enabled = false }` so Lazy keeps a clear record and you can re‑enable later.
+- **Keep base config small**: general maps/options/autocmds only. Feature-specific settings live with their plugins.
+- **Pin, then update intentionally**: keep `lazy-lock.json` in Git; update with `:Lazy sync` when you choose.
+- **Test incrementally**: add one plugin at a time, start Neovim, and check `:checkhealth` and `:messages`.
+- **Name consistently**: files like `ui.lua`, `lsp.lua`, `git.lua`, `coding.lua`, `tools.lua`.
+- **Project overrides**: use a trusted `.lazy.lua` in a project root for local tweaks without touching global config.
+
+#### Common tasks
+
+- Add a plugin:
+
+```lua
+-- lua/plugins/git.lua
+return {
+  { "lewis6991/gitsigns.nvim", opts = { current_line_blame = true } },
+}
+```
+
+- Disable a plugin:
+
+```lua
+-- lua/plugins/disabled.lua
+return {
+  { "some/unused.nvim", enabled = false },
+}
+```
+
+- Change colorscheme:
+
+```lua
+-- lua/plugins/core.lua
+return {
+  { "folke/tokyonight.nvim", lazy = false, priority = 1000 },
+  { "LazyVim/LazyVim", opts = { colorscheme = "tokyonight" } },
+}
+```
+
+#### Troubleshooting
+
+- Run `:checkhealth` and `:Lazy build` after upgrades.
+- If UI looks wrong, try a different theme or comment bufferline temporarily.
+- Clear compiled cache: remove `~/.local/share/nvim/lazy` and restart.
+

--- a/nvim/README.md
+++ b/nvim/README.md
@@ -1,51 +1,53 @@
-### LazyVim Starter (Lean)
+### My LazyVim config
 
-This is a clean, documented LazyVim setup you can use as a solid base. It trims unused plugins and avoids common pitfalls (like colorscheme + bufferline highlight issues).
+This is my own lazyvim config that im using right now.
 
-#### Install
+#### Neovim Manager - [bob](https://github.com/MordechaiHadad/bob)
+Im personaly a big fan of bob, it manages my neovim installation really well.
 
-1) Backup your current config and link/copy this folder to `~/.config/nvim`.
+Im usually working on MacOS/Linux but the installation process should be fairly similiar, you should probably check bob's readme anyway.
 
 ```bash
-mv ~/.config/nvim ~/.config/nvim.bak 2>/dev/null || true
-cp -r /workspace/nvim ~/.config/nvim
+wget https://github.com/MordechaiHadad/bob/releases/download/v4.1.2/bob-macos-x86_64.zip
+unzip -j bob-macos-x86_64.zip
+chmod +x bob
+mv bob ~/.local/bin/
+bob
 ```
 
-2) Start Neovim. Lazy will bootstrap itself automatically.
+#### Neovim Installation
+This is fairly easy, just run `bob install stable` at it will download, install and configure the neovim for you.
+You will probably have to create some blank files in `~/.config` directory, just read the logs.
+
+#### Applying Configuration
+Remember to backup your current config because this from now on, anything can happen.
+These steps assumes that you moved your nvim config from the `~/.config` directory.
+
+```bash
+cd ~/.config
+git clone https://github.com/artpods56/lazynvim.conf
+mv lazyvim.conf nvim
+```
+
+All done, LazyVim should bootstrap itself and load all the plugins.
 
 #### Structure
 
 ```
 ~/.config/nvim
-├── init.lua                  # sets leaders and loads lazy
+├── init.lua                 # sets leaders and loads lazy
 ├── lua
 │   ├── config
-│   │   ├── lazy.lua          # bootstrap lazy.nvim + plugin spec imports
-│   │   ├── options.lua       # core editor options
-│   │   ├── keymaps.lua       # minimal base keymaps
-│   │   └── autocmds.lua      # small generic autocmds
-│   └── plugins               # your plugin specs (one concern per file)
+│   │   ├── lazy.lua         # bootstrap lazy.nvim + plugin spec imports
+│   │   ├── options.lua       # editor options
+│   │   ├── keymaps.lua       # base keymaps
+│   │   └── autocmds.lua      # generic autocmds
+│   └── plugins              # plugin specs 
 │       ├── core.lua          # colorscheme and LazyVim opts
-│       ├── ui.lua            # bufferline, lualine, theme plugin
-│       └── disabled.lua      # plugins disabled explicitly
+│       ├── ui.lua            # theme plugins
+│       └── disabled.lua      # disabled plugins
 └── README.md
 ```
-
-#### Why this fixes your startup error
-
-LazyVim’s built‑in `colorscheme.lua` sometimes overrides bufferline highlights in ways that break when themes/plugins change. This starter provides a minimal `bufferline` config and loads a theme plugin explicitly, avoiding the problematic highlight mutation path.
-
-#### Best practices
-
-- **One concern per file**: put each feature or plugin family in its own spec file in `lua/plugins/`.
-- **Prefer `opts` over imperative config**: supply options tables; avoid calling setup twice.
-- **Disable unused plugins**: use `lua/plugins/disabled.lua` with `{ name, enabled = false }` so Lazy keeps a clear record and you can re‑enable later.
-- **Keep base config small**: general maps/options/autocmds only. Feature-specific settings live with their plugins.
-- **Pin, then update intentionally**: keep `lazy-lock.json` in Git; update with `:Lazy sync` when you choose.
-- **Test incrementally**: add one plugin at a time, start Neovim, and check `:checkhealth` and `:messages`.
-- **Name consistently**: files like `ui.lua`, `lsp.lua`, `git.lua`, `coding.lua`, `tools.lua`.
-- **Project overrides**: use a trusted `.lazy.lua` in a project root for local tweaks without touching global config.
-
 #### Common tasks
 
 - Add a plugin:

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,0 +1,10 @@
+-- Entry point for Neovim using LazyVim
+-- Keeps this repo self-contained and easy to expand.
+
+-- Leader must be set before loading lazy.nvim
+vim.g.mapleader = " "
+vim.g.maplocalleader = ","
+
+-- Load core options/keymaps/autocmds and bootstrap lazy.nvim
+require("config.lazy")
+

--- a/nvim/lua/config/autocmds.lua
+++ b/nvim/lua/config/autocmds.lua
@@ -1,0 +1,12 @@
+-- Place small, generic autocmds here.
+
+local group = vim.api.nvim_create_augroup("UserConfig", { clear = true })
+
+-- Resize splits when window size changes
+vim.api.nvim_create_autocmd("VimResized", {
+  group = group,
+  callback = function()
+    vim.cmd("tabdo wincmd =")
+  end,
+})
+

--- a/nvim/lua/config/keymaps.lua
+++ b/nvim/lua/config/keymaps.lua
@@ -1,0 +1,6 @@
+-- Basic keymaps. Keep minimal; feature maps belong with their plugins.
+
+local map = vim.keymap.set
+
+map("n", "<leader>qq", ":qa<cr>", { desc = "Quit all" })
+

--- a/nvim/lua/config/lazy.lua
+++ b/nvim/lua/config/lazy.lua
@@ -1,0 +1,38 @@
+-- Bootstrap and configure lazy.nvim and LazyVim plugin specs
+
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+require("lazy").setup({
+  spec = {
+    -- LazyVim and import the default plugins
+    { "LazyVim/LazyVim", import = "lazyvim.plugins" },
+    -- import/override with your plugins
+    { import = "plugins" },
+  },
+  defaults = { lazy = false, version = false },
+  install = { colorscheme = { "tokyonight", "catppuccin" } },
+  checker = { enabled = false },
+  performance = {
+    rtp = {
+      disabled_plugins = {
+        "gzip",
+        "tarPlugin",
+        "tohtml",
+        "tutor",
+        "zipPlugin",
+      },
+    },
+  },
+})
+

--- a/nvim/lua/config/options.lua
+++ b/nvim/lua/config/options.lua
@@ -1,0 +1,13 @@
+-- Core editor options. Keep these minimal and sane.
+
+local opt = vim.opt
+
+opt.number = true
+opt.relativenumber = true
+opt.mouse = "a"
+opt.clipboard = "unnamedplus"
+opt.expandtab = true
+opt.shiftwidth = 2
+opt.tabstop = 2
+opt.termguicolors = true
+

--- a/nvim/lua/plugins/core.lua
+++ b/nvim/lua/plugins/core.lua
@@ -1,0 +1,11 @@
+-- Core LazyVim customizations: UI theme, small defaults.
+
+return {
+  {
+    "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "tokyonight",
+    },
+  },
+}
+

--- a/nvim/lua/plugins/disabled.lua
+++ b/nvim/lua/plugins/disabled.lua
@@ -1,0 +1,8 @@
+-- Disable plugins you don't use to keep things lean
+
+return {
+  { "quarto-dev/quarto-nvim", enabled = false },
+  { "jmbuhr/otter.nvim", enabled = false },
+  { "3rd/image.nvim", enabled = false },
+}
+

--- a/nvim/lua/plugins/essentials.lua
+++ b/nvim/lua/plugins/essentials.lua
@@ -1,0 +1,25 @@
+-- Essentials: treesitter, LSP base, formatting, finder
+
+return {
+  -- Treesitter
+  {
+    "nvim-treesitter/nvim-treesitter",
+    build = ":TSUpdate",
+    opts = {
+      highlight = { enable = true },
+      indent = { enable = true },
+      ensure_installed = { "lua", "vim", "vimdoc", "bash", "markdown", "markdown_inline", "json", "yaml", "toml" },
+    },
+  },
+
+  -- LSP config (LazyVim will install mason & base servers)
+  { "neovim/nvim-lspconfig" },
+
+  -- Formatting & linting via conform and nvim-lint (already in LazyVim but ok to keep)
+  { "stevearc/conform.nvim" },
+  { "mfussenegger/nvim-lint" },
+
+  -- Finder (fzf-lua is lightweight and fast)
+  { "ibhagwan/fzf-lua" },
+}
+

--- a/nvim/lua/plugins/ui.lua
+++ b/nvim/lua/plugins/ui.lua
@@ -1,0 +1,41 @@
+-- Minimal UI layer to avoid colorscheme/bufferline issues.
+
+return {
+  -- Theme plugins you actually use
+  { "folke/tokyonight.nvim", lazy = false, priority = 1000 },
+
+  -- Bufferline with a safe, minimal setup
+  {
+    "akinsho/bufferline.nvim",
+    event = "VeryLazy",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    opts = function()
+      return {
+        options = {
+          diagnostics = "nvim_lsp",
+          always_show_bufferline = true,
+          offsets = {
+            { filetype = "neo-tree", text = "Explorer", separator = true, text_align = "left" },
+          },
+        },
+        -- Override any upstream LazyVim highlight function with a no-op to
+        -- avoid colorscheme.lua integration issues
+        highlights = function()
+          return {}
+        end,
+      }
+    end,
+    config = function(_, opts)
+      -- Explicitly setup bufferline ourselves to avoid upstream config side-effects
+      require("bufferline").setup(opts)
+    end,
+  },
+
+  -- Statusline
+  {
+    "nvim-lualine/lualine.nvim",
+    event = "VeryLazy",
+    opts = { options = { theme = "auto", globalstatus = true } },
+  },
+}
+


### PR DESCRIPTION
Refactor LazyVim configuration into a clean, modular starter, disabling unused plugins and explicitly configuring bufferline to resolve startup errors.

The original error stemmed from LazyVim's `colorscheme.lua` attempting to dynamically generate `bufferline` highlights in a way that conflicted with certain themes or plugin interactions. This PR addresses it by providing a direct `bufferline` configuration with a no-op `highlights` function, ensuring it controls its own styling and avoids the problematic upstream highlight mutation path.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c8f7848-3501-4aee-80a4-02b5bbd8a4ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c8f7848-3501-4aee-80a4-02b5bbd8a4ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

